### PR TITLE
update livebook image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   livebook:
-    image: livebook/livebook
+    image: ghcr.io/livebook-dev/livebook
     volumes:
       - ./docs:/data
     ports:


### PR DESCRIPTION
This pull request updates the Livebook Docker image source from [livebook/livebook] to [ghcr.io/livebook-dev/livebook]. It seems like the [livebook/livebook] source has been deleted.

```
$ docker compose up -d
[+] Running 1/1
 ✘ livebook Error                                                                                   1.2s
Error response from daemon: pull access denied for livebook/livebook, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

![CleanShot 2023-11-23 at 11 26 24](https://github.com/koga1020/phoenix-docker-with-livebook/assets/7563926/646d0e73-8478-4bce-83ba-739ad4c4121f)


The app gets started properly after updating the image source.

[ghcr.io/livebook-dev/livebook]: https://github.com/livebook-dev/livebook/pkgs/container/livebook
[livebook/livebook]: https://hub.docker.com/r/livebook/livebook/tags